### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push]
+permissions:
+  contents: read
 jobs:
   lighthouseci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Terfno/terfno.github.io/security/code-scanning/1](https://github.com/Terfno/terfno.github.io/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/lighthouse-ci.yml` at the workflow root (top-level) so it applies to all jobs unless overridden. The minimal safe baseline recommended by CodeQL is `contents: read`, which is sufficient for `actions/checkout` and typical read-only CI tasks.

Best single fix without changing functionality:
- Edit `.github/workflows/lighthouse-ci.yml`.
- Insert:
  ```yml
  permissions:
    contents: read
  ```
  directly after `on: [push]` (before `jobs:`), keeping existing jobs and steps unchanged.

No imports, methods, or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
